### PR TITLE
Add websocket send error handling

### DIFF
--- a/dom/src/main/scala/org/http4s/dom/WebSocketClient.scala
+++ b/dom/src/main/scala/org/http4s/dom/WebSocketClient.scala
@@ -138,10 +138,40 @@ object WebSocketClient {
             .map(_.merge)
 
         override def sendText(text: String): F[Unit] =
-          F.delay(ws.send(text))
+          F.defer {
+            ws.readyState match {
+              case WebSocket.CONNECTING =>
+                F.raiseError(new WebSocketException("WebSocket is still connecting"))
+              case WebSocket.OPEN =>
+                F.delay(ws.send(text)).handleErrorWith { e =>
+                  F.raiseError(new WebSocketException(s"Failed to send text message: ${e.getMessage}"))
+                }
+              case WebSocket.CLOSING =>
+                F.raiseError(new WebSocketException("WebSocket is closing"))
+              case WebSocket.CLOSED =>
+                F.raiseError(new WebSocketException("WebSocket is already closed"))
+              case _ =>
+                F.raiseError(new WebSocketException("WebSocket is in an unknown state"))
+            }
+          }
 
         override def sendBinary(bytes: ByteVector): F[Unit] =
-          F.delay(ws.send(bytes.toJSArrayBuffer))
+          F.defer {
+            ws.readyState match {
+              case WebSocket.CONNECTING =>
+                F.raiseError(new WebSocketException("WebSocket is still connecting"))
+              case WebSocket.OPEN =>
+                F.delay(ws.send(bytes.toJSArrayBuffer)).handleErrorWith { e =>
+                  F.raiseError(new WebSocketException(s"Failed to send binary message: ${e.getMessage}"))
+                }
+              case WebSocket.CLOSING =>
+                F.raiseError(new WebSocketException("WebSocket is closing"))
+              case WebSocket.CLOSED =>
+                F.raiseError(new WebSocketException("WebSocket is already closed"))
+              case _ =>
+                F.raiseError(new WebSocketException("WebSocket is in an unknown state"))
+            }
+          }
 
         def send(wsf: WSDataFrame): F[Unit] = errorOr {
           wsf match {

--- a/tests/src/test/scala/org/http4s/dom/WebSocketErrorHandlingSuite.scala
+++ b/tests/src/test/scala/org/http4s/dom/WebSocketErrorHandlingSuite.scala
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2021 http4s.org
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.http4s.dom
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.http4s.Uri
+import org.http4s.client.websocket.WSFrame
+import org.http4s.client.websocket.WSRequest
+import org.http4s.dom.BuildInfo.fileServicePort
+import scodec.bits.ByteVector
+
+class WebSocketErrorHandlingSuite extends CatsEffectSuite {
+
+  test("fail when sending after connection is closed") {
+    WebSocketClient[IO]
+      .connectHighLevel(
+        WSRequest(Uri.fromString(s"ws://localhost:${fileServicePort}/ws").toOption.get))
+      .use { conn =>
+        for {
+          _ <- conn.send(WSFrame.Text("test"))
+          closeFrame <- conn.closeFrame.get
+          result <- conn.send(WSFrame.Text("should fail")).attempt
+        } yield {
+          assert(result.isLeft)
+          result.left.toOption.get match {
+            case e: WebSocketException =>
+              assert(e.reason.contains("WebSocket is already closed") || 
+                     e.reason.contains("WebSocket is closing"))
+            case _ => fail("Expected WebSocketException")
+          }
+        }
+      }
+  }
+
+  test("fail when sending binary after connection is closed") {
+    WebSocketClient[IO]
+      .connectHighLevel(
+        WSRequest(Uri.fromString(s"ws://localhost:${fileServicePort}/ws").toOption.get))
+      .use { conn =>
+        for {
+          _ <- conn.send(WSFrame.Binary(ByteVector(1, 2, 3)))
+          closeFrame <- conn.closeFrame.get
+          result <- conn.send(WSFrame.Binary(ByteVector(4, 5, 6))).attempt
+        } yield {
+          assert(result.isLeft)
+          result.left.toOption.get match {
+            case e: WebSocketException =>
+              assert(e.reason.contains("WebSocket is already closed") || 
+                     e.reason.contains("WebSocket is closing"))
+            case _ => fail("Expected WebSocketException")
+          }
+        }
+      }
+  }
+
+  test("handle send errors gracefully") {
+    WebSocketClient[IO]
+      .connectHighLevel(
+        WSRequest(Uri.fromString(s"ws://localhost:${fileServicePort}/ws").toOption.get))
+      .use { conn =>
+        // This test checks that the error handling wrapper works correctly
+        // In a real scenario, send errors might occur due to network issues,
+        // buffer overflow, or other browser-specific conditions
+        conn.send(WSFrame.Text("test message")).attempt.map { result =>
+          assert(result.isRight, "Send should succeed when connection is open")
+        }
+      }
+  }
+
+  test("fail when sending fragmented frames") {
+    WebSocketClient[IO]
+      .connectHighLevel(
+        WSRequest(Uri.fromString(s"ws://localhost:${fileServicePort}/ws").toOption.get))
+      .use { conn =>
+        val fragmentedFrame = WSFrame.Text("fragment", last = false)
+        conn.send(fragmentedFrame).attempt.map { result =>
+          assert(result.isLeft)
+          result.left.toOption.get match {
+            case e: IllegalArgumentException =>
+              assert(e.getMessage.contains("DataFrames cannot be fragmented"))
+            case _ => fail("Expected IllegalArgumentException for fragmented frames")
+          }
+        }
+      }
+  }
+
+}


### PR DESCRIPTION
Add error handling to `WebSocketClient` for `ws.send` failures and various connection states.

This PR enhances `sendText` and `sendBinary` methods to check the WebSocket `readyState` before sending, providing specific `WebSocketException` messages for `CONNECTING`, `CLOSING`, and `CLOSED` states. It also wraps any JavaScript exceptions during `ws.send()` in a `WebSocketException` for consistent error reporting.

---
<a href="https://cursor.com/background-agent?bcId=bc-26334963-971d-4f41-b844-e5e08bc0f2bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26334963-971d-4f41-b844-e5e08bc0f2bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

